### PR TITLE
56 v1.2.0 enhancements

### DIFF
--- a/.github/workflows/autodocker-ci.yml
+++ b/.github/workflows/autodocker-ci.yml
@@ -17,6 +17,9 @@ jobs:
         env:
           DEPLOY_BRANCH: ${{secrets.DEPLOY_BRANCH}}
           DOCKERHUB_ORG: ${{secrets.DOCKERHUB_ORG}}
+          DOCKERHUB_PW: ${{secrets.DOCKERHUB_PW}}
+          DOCKERHUB_UN: ${{secrets.DOCKERHUB_UN}}
+          DOCKERHUB_URL: ${{secrets.DOCKERHUB_URL}}
           LANG: C.UTF-8
           LC_ALL: C.UTF-8
         run: |
@@ -57,6 +60,9 @@ jobs:
           DEPLOY_BRANCH: ${{secrets.DEPLOY_BRANCH}}
           DOCKERHUB_ORG: ${{secrets.DOCKERHUB_ORG}}
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          DOCKERHUB_PW: ${{secrets.DOCKERHUB_PW}}
+          DOCKERHUB_UN: ${{secrets.DOCKERHUB_UN}}
+          DOCKERHUB_URL: ${{secrets.DOCKERHUB_URL}}
           LANG: C.UTF-8
           LC_ALL: C.UTF-8
         run: |
@@ -77,6 +83,9 @@ jobs:
           DEPLOY_BRANCH: ${{secrets.DEPLOY_BRANCH}}
           DOCKERHUB_ORG: ${{secrets.DOCKERHUB_ORG}}
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          DOCKERHUB_PW: ${{secrets.DOCKERHUB_PW}}
+          DOCKERHUB_UN: ${{secrets.DOCKERHUB_UN}}
+          DOCKERHUB_URL: ${{secrets.DOCKERHUB_URL}}
           LANG: C.UTF-8
           LC_ALL: C.UTF-8
         run: |

--- a/.github/workflows/container-ci.yml
+++ b/.github/workflows/container-ci.yml
@@ -77,6 +77,7 @@ jobs:
           DOCKERHUB_UN: ${{secrets.DOCKERHUB_UN}}
           DOCKERHUB_URL: ${{secrets.DOCKERHUB_URL}}
         run: |
+          echo ${DOCKERHUB_URL}
           python3 scripts/functions.py 'login'
 
       - name: Update relations.yaml

--- a/.github/workflows/container-ci.yml
+++ b/.github/workflows/container-ci.yml
@@ -77,7 +77,6 @@ jobs:
           DOCKERHUB_UN: ${{secrets.DOCKERHUB_UN}}
           DOCKERHUB_URL: ${{secrets.DOCKERHUB_URL}}
         run: |
-          echo ${DOCKERHUB_URL}
           python3 scripts/functions.py 'login'
 
       - name: Update relations.yaml

--- a/.github/workflows/container-ci.yml
+++ b/.github/workflows/container-ci.yml
@@ -26,7 +26,7 @@ jobs:
           git config user.name github-actions
           git config user.email github-actions@github.com
           python3 -m pip install numpy==1.19.2 PyGitHub==1.53 PyYAML==5.3.1
-          python3 scripts/functions.py 'fetch_develop'
+          python3 scripts/functions.py 'fetch_deploy_branch'
           git show origin/main:relations.yaml > main_relation.yml
           #Check to see if more than one Dockerfile has been updated, and if so, error out.
           docker_file=`python3 scripts/functions.py 'check_dockerfile_count'`
@@ -49,6 +49,7 @@ jobs:
         env:
           DEPLOY_BRANCH: ${{secrets.DEPLOY_BRANCH}}
           DOCKERHUB_ORG: ${{secrets.DOCKERHUB_ORG}}
+          DOCKERHUB_URL: ${{secrets.DOCKERHUB_URL}}
           docker_file: ${{ steps.checkBuild.outputs.docker_file }}
         run: |
           echo "New or updated Dockerfile found, building image and running CI"
@@ -61,10 +62,22 @@ jobs:
         env:
           DEPLOY_BRANCH: ${{secrets.DEPLOY_BRANCH}}
           DOCKERHUB_ORG: ${{secrets.DOCKERHUB_ORG}}
+          DOCKERHUB_PW: ${{secrets.DOCKERHUB_PW}}
+          DOCKERHUB_UN: ${{secrets.DOCKERHUB_UN}}
+          DOCKERHUB_URL: ${{secrets.DOCKERHUB_URL}}
           docker_file: ${{ steps.checkBuild.outputs.docker_file }}
         run: |
           python3 scripts/ci_image.py "${DOCKERHUB_ORG}" "${docker_file}"
           echo "::set-output name=is_test::$(python3 scripts/functions.py 'check_test' ${docker_file})"
+
+      - name: Docker Login
+        id: docker_login
+        env:
+          DOCKERHUB_PW: ${{secrets.DOCKERHUB_PW}}
+          DOCKERHUB_UN: ${{secrets.DOCKERHUB_UN}}
+          DOCKERHUB_URL: ${{secrets.DOCKERHUB_URL}}
+        run: |
+          python3 scripts/functions.py 'login'
 
       - name: Update relations.yaml
         id: updateYaml
@@ -72,8 +85,6 @@ jobs:
         env:
           DOCKERHUB_ORG: ${{secrets.DOCKERHUB_ORG}}
           DEPLOY_BRANCH: ${{secrets.DEPLOY_BRANCH}}
-          DOCKER_PASSWORD: ${{secrets.DOCKERHUB_PW}}
-          DOCKER_USERNAME: ${{secrets.DOCKERHUB_UN}}
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
           docker_file: ${{ steps.checkBuild.outputs.docker_file }}
         run: |
@@ -102,25 +113,26 @@ jobs:
           github_token: ${{secrets.GITHUB_TOKEN}}
           branch: "${{ github.ref }}"
 
-      - name: DockerHub_Login
-        id: dockerHubLogin
-        uses: actions-hub/docker/login@master
-        env:
-          DOCKER_PASSWORD: ${{secrets.DOCKERHUB_PW}}
-          DOCKER_USERNAME: ${{secrets.DOCKERHUB_UN}}
-
       - name: Push_to_DockerHub
+        env:
+          DEPLOY_BRANCH: ${{secrets.DEPLOY_BRANCH}}
+          DOCKERHUB_ORG: ${{secrets.DOCKERHUB_ORG}}
+          DOCKERHUB_PW: ${{secrets.DOCKERHUB_PW}}
+          DOCKERHUB_UN: ${{secrets.DOCKERHUB_UN}}
+          DOCKERHUB_URL: ${{secrets.DOCKERHUB_URL}}
         id: pushToDockerHub
         if: steps.testImage.outputs.is_test == 'False'
-        uses: actions-hub/docker@master
-        with:
-          args: push ${DOCKER_IMAGE}
+        run: |
+          python3 scripts/functions.py push_images
 
       - name: CI Only
         id: runAllCI
         if: steps.checkBuild.outputs.build == 'false' || steps.testImage.outputs.is_test == 'True'
         env:
           DOCKERHUB_ORG: ${{secrets.DOCKERHUB_ORG}}
+          DOCKERHUB_PW: ${{secrets.DOCKERHUB_PW}}
+          DOCKERHUB_UN: ${{secrets.DOCKERHUB_UN}}
+          DOCKERHUB_URL: ${{secrets.DOCKERHUB_URL}}
         run: |
           python3 -m pip install numpy==1.19.2 PyGitHub==1.53 PyYAML==5.3.1
           python3 scripts/ci_latest_images.py "${DOCKERHUB_ORG}" relations.yaml

--- a/scripts/ci_image.py
+++ b/scripts/ci_image.py
@@ -51,10 +51,10 @@ def get_test_list(filename):
         return testinfo_list
 
 
-def run_docker_get_output(imagename, cmd, workdir=None, user=None):
+def run_docker_get_output(image_name, cmd, workdir=None, user=None):
     """
     Launch docker process with run command passing the cmd.
-    :param imagename: str: name of the image to run
+    :param image_name: str: name of the image to run
     :param cmd: str: commmand to run inside the image
     :param workdir: str: optional flag to run in a particular directory
     :param user: str: optional flag to run as a particular user
@@ -67,27 +67,27 @@ def run_docker_get_output(imagename, cmd, workdir=None, user=None):
         options += "--user {} ".format(user)
     options += "-i --rm "
     print("Testing image {} with: docker run {} {} {}".format(
-        imagename, options, imagename, cmd))
-    docker_cmd = "docker run {} {} {}".format(options, imagename, cmd)
+        image_name, options, image_name, cmd))
+    docker_cmd = "docker run {} {} {}".format(options, image_name, cmd)
     return run_bash_cmd(docker_cmd, ignore_non_zero_exit_status=True)
 
 
-def run_tests(imagename, unittest_filepath):
+def run_tests(image_name, unittest_filepath):
     """
-    Run all tests contained in a unittest_filename against imagename
-    :param imagename: str: name of the image to test
+    Run all tests contained in a unittest_filename against image_name
+    :param image_name: str: name of the image to test
     :param unittest_filepath: str path to unittest.yml file
     :return: bool: true if we had an error
     """
     had_error = False
     for cmd, expect_text in get_test_list(unittest_filepath):
         expect_pattern = re.compile(expect_text, re.DOTALL)
-        docker_output = run_docker_get_output(imagename, cmd)
+        docker_output = run_docker_get_output(image_name, cmd)
         if not re.match(expect_pattern, docker_output):
             print_test_error(cmd, expect_text, docker_output)
             had_error = True
         docker_output_with_options = run_docker_get_output(
-            imagename, cmd, workdir=TEST_WORKDIR)
+            image_name, cmd, workdir=TEST_WORKDIR)
         if not re.match(expect_pattern, docker_output_with_options):
             print_test_error(cmd + " (with workdir and user options)",
                              expect_text, docker_output_with_options)
@@ -135,7 +135,7 @@ def get_unittest_file_paths(path_list):
 def find_and_run_tests(owner, changed_paths):
     """
     Find an run tests based on a docker ownername (used to build image name) and a list of paths
-    :param owner: str: prefix of docker imagename
+    :param owner: str: prefix of docker image_name
     :param changed_paths: [str]: list of paths that were changed and may need to be tested
     :return: bool: true when we had errors
     """
@@ -146,8 +146,10 @@ def find_and_run_tests(owner, changed_paths):
         parts = unittest_path.split(sep="/")
         if len(parts):
             tool, tag, _ = parts
-            imagename = "{}/{}:{}".format(owner, tool, tag).replace("+", "_")
-            had_error = run_tests(imagename, unittest_path)
+            image_name = "{}/{}:{}".format(owner, tool, tag).replace("+", "_")
+            if not str(os.environ.get('DOCKERHUB_URL')).lower() == "none" or str(os.environ.get('DOCKERHUB_URL')).lower() == 'null' or os.environ.get('DOCKERHUB_URL') == None:
+                image_name = "{}/{}".format(os.environ.get('DOCKERHUB_URL'), image_name)
+            had_error = run_tests(image_name, unittest_path)
             tested_images += 1
             if had_error:
                 images_with_errors += 1
@@ -169,7 +171,6 @@ def main():
             "Usage python3 tests/ci_image.py <docker_owner> [<unittest_or_dockerfile_path>...]")
         sys.exit(1)
     else:
-        functions.docker_login()
         owner = sys.argv[1]
         changed_paths = sys.argv[2:] if len(sys.argv) > 2 else []
         had_errors = find_and_run_tests(owner, changed_paths)

--- a/scripts/ci_image.py
+++ b/scripts/ci_image.py
@@ -147,7 +147,7 @@ def find_and_run_tests(owner, changed_paths):
         if len(parts):
             tool, tag, _ = parts
             image_name = "{}/{}:{}".format(owner, tool, tag).replace("+", "_")
-            if not str(os.environ.get('DOCKERHUB_URL')).lower() == "none" or str(os.environ.get('DOCKERHUB_URL')).lower() == 'null' or os.environ.get('DOCKERHUB_URL') == None:
+            if not (str(os.environ.get('DOCKERHUB_URL')).lower() == "none" or str(os.environ.get('DOCKERHUB_URL')).lower() == 'null' or os.environ.get('DOCKERHUB_URL') == None):
                 image_name = "{}/{}".format(os.environ.get('DOCKERHUB_URL'), image_name)
             had_error = run_tests(image_name, unittest_path)
             tested_images += 1

--- a/scripts/ci_image.py
+++ b/scripts/ci_image.py
@@ -147,7 +147,7 @@ def find_and_run_tests(owner, changed_paths):
         if len(parts):
             tool, tag, _ = parts
             image_name = "{}/{}:{}".format(owner, tool, tag).replace("+", "_")
-            if 'DOCKERHUB_URL' in os.environ and not (str(os.environ.get('DOCKERHUB_URL')).lower() == "none" or str(os.environ.get('DOCKERHUB_URL')).lower() == 'null' or os.environ.get('DOCKERHUB_URL') == None):
+            if not (str(os.environ.get('DOCKERHUB_URL')).lower() == "none" or str(os.environ.get('DOCKERHUB_URL')).lower() == 'null' or os.environ.get('DOCKERHUB_URL') == None or os.environ.get('DOCKERHUB_URL') == ''):
                 image_name = "{}/{}".format(os.environ.get('DOCKERHUB_URL'), image_name)
             had_error = run_tests(image_name, unittest_path)
             tested_images += 1

--- a/scripts/ci_image.py
+++ b/scripts/ci_image.py
@@ -147,7 +147,7 @@ def find_and_run_tests(owner, changed_paths):
         if len(parts):
             tool, tag, _ = parts
             image_name = "{}/{}:{}".format(owner, tool, tag).replace("+", "_")
-            if not (str(os.environ.get('DOCKERHUB_URL')).lower() == "none" or str(os.environ.get('DOCKERHUB_URL')).lower() == 'null' or os.environ.get('DOCKERHUB_URL') == None):
+            if 'DOCKERHUB_URL' in os.environ and not (str(os.environ.get('DOCKERHUB_URL')).lower() == "none" or str(os.environ.get('DOCKERHUB_URL')).lower() == 'null' or os.environ.get('DOCKERHUB_URL') == None):
                 image_name = "{}/{}".format(os.environ.get('DOCKERHUB_URL'), image_name)
             had_error = run_tests(image_name, unittest_path)
             tested_images += 1

--- a/scripts/ci_image.py
+++ b/scripts/ci_image.py
@@ -12,6 +12,7 @@ import subprocess
 import yaml
 import re
 import difflib
+import functions
 
 UNITTEST_FILENAME = "unittest.yml"
 TEST_WORKDIR = "/data"
@@ -157,7 +158,8 @@ def find_and_run_tests(owner, changed_paths):
         print("ERROR: No images tested, unit test may not have been found correctly.")
         had_errors = True
     else:
-        print("Tested {} images. Images with errors: {}".format(tested_images, images_with_errors))
+        print("Tested {} images. Images with errors: {}".format(
+            tested_images, images_with_errors))
     return had_errors
 
 
@@ -167,6 +169,7 @@ def main():
             "Usage python3 tests/ci_image.py <docker_owner> [<unittest_or_dockerfile_path>...]")
         sys.exit(1)
     else:
+        functions.docker_login()
         owner = sys.argv[1]
         changed_paths = sys.argv[2:] if len(sys.argv) > 2 else []
         had_errors = find_and_run_tests(owner, changed_paths)

--- a/scripts/ci_latest_images.py
+++ b/scripts/ci_latest_images.py
@@ -8,6 +8,7 @@ import sys
 import re
 import subprocess
 import yaml
+import functions
 
 
 def load_yaml(master_yaml):
@@ -41,6 +42,7 @@ def main():
             "Usage python3 scripts/ci_latest_images.py <docker_owner> <relations.yaml path>")
         sys.exit(1)
     else:
+        functions.docker_login()
         owner = sys.argv[1]
         relations = load_yaml(os.path.abspath(sys.argv[2]))
         latest_images = relations['latest']

--- a/scripts/ci_latest_images.py
+++ b/scripts/ci_latest_images.py
@@ -48,7 +48,7 @@ def main():
         for image in latest_images:
             tag = latest_images[image]
             image_name = "{}/{}:{}".format(owner, image, tag).replace("+", "_")
-            if not str(os.environ.get('DOCKERHUB_URL')).lower() == "none" or str(os.environ.get('DOCKERHUB_URL')).lower() == 'null' or os.environ.get('DOCKERHUB_URL') == None:
+            if not (str(os.environ.get('DOCKERHUB_URL')).lower() == "none" or str(os.environ.get('DOCKERHUB_URL')).lower() == 'null' or os.environ.get('DOCKERHUB_URL') == None):
                 image_name = "{}/{}".format(os.environ.get('DOCKERHUB_URL'), image_name)
             pull_image(image_name)
             test_path = "{}/{}/unittest.yml".format(image, tag)

--- a/scripts/ci_latest_images.py
+++ b/scripts/ci_latest_images.py
@@ -48,7 +48,7 @@ def main():
         for image in latest_images:
             tag = latest_images[image]
             image_name = "{}/{}:{}".format(owner, image, tag).replace("+", "_")
-            if 'DOCKERHUB_URL' in os.environ and not (str(os.environ.get('DOCKERHUB_URL')).lower() == "none" or str(os.environ.get('DOCKERHUB_URL')).lower() == 'null' or os.environ.get('DOCKERHUB_URL') == None):
+            if not (str(os.environ.get('DOCKERHUB_URL')).lower() == "none" or str(os.environ.get('DOCKERHUB_URL')).lower() == 'null' or os.environ.get('DOCKERHUB_URL') == None or os.environ.get('DOCKERHUB_URL') == ''):
                 image_name = "{}/{}".format(os.environ.get('DOCKERHUB_URL'), image_name)
             pull_image(image_name)
             test_path = "{}/{}/unittest.yml".format(image, tag)

--- a/scripts/ci_latest_images.py
+++ b/scripts/ci_latest_images.py
@@ -48,7 +48,7 @@ def main():
         for image in latest_images:
             tag = latest_images[image]
             image_name = "{}/{}:{}".format(owner, image, tag).replace("+", "_")
-            if not (str(os.environ.get('DOCKERHUB_URL')).lower() == "none" or str(os.environ.get('DOCKERHUB_URL')).lower() == 'null' or os.environ.get('DOCKERHUB_URL') == None):
+            if 'DOCKERHUB_URL' in os.environ and not (str(os.environ.get('DOCKERHUB_URL')).lower() == "none" or str(os.environ.get('DOCKERHUB_URL')).lower() == 'null' or os.environ.get('DOCKERHUB_URL') == None):
                 image_name = "{}/{}".format(os.environ.get('DOCKERHUB_URL'), image_name)
             pull_image(image_name)
             test_path = "{}/{}/unittest.yml".format(image, tag)

--- a/scripts/ci_latest_images.py
+++ b/scripts/ci_latest_images.py
@@ -42,13 +42,14 @@ def main():
             "Usage python3 scripts/ci_latest_images.py <docker_owner> <relations.yaml path>")
         sys.exit(1)
     else:
-        functions.docker_login()
         owner = sys.argv[1]
         relations = load_yaml(os.path.abspath(sys.argv[2]))
         latest_images = relations['latest']
         for image in latest_images:
             tag = latest_images[image]
             image_name = "{}/{}:{}".format(owner, image, tag).replace("+", "_")
+            if not str(os.environ.get('DOCKERHUB_URL')).lower() == "none" or str(os.environ.get('DOCKERHUB_URL')).lower() == 'null' or os.environ.get('DOCKERHUB_URL') == None:
+                image_name = "{}/{}".format(os.environ.get('DOCKERHUB_URL'), image_name)
             pull_image(image_name)
             test_path = "{}/{}/unittest.yml".format(image, tag)
             test_command = "python3 scripts/ci_image.py \"{}\" {}".format(

--- a/scripts/functions.py
+++ b/scripts/functions.py
@@ -27,7 +27,7 @@ def get_current_branch_name():
     return subprocess.Popen(get_branch_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True).communicate()[0]
 
 
-def fetch_develop():
+def fetch_deploy_branch():
     """
     Keep track of which branch we are on, and since we are on a detached head, and we need to be able to go back to it.
     """
@@ -127,6 +127,9 @@ def build_docker_cmd(command, owner, tool, version):
     """
     # Ensure the command is lower-case
     command = command.lower()
+    # Check to see if URL is needed
+    if not str(os.environ.get('DOCKERHUB_URL')).lower() == "none" or str(os.environ.get('DOCKERHUB_URL')).lower() == 'null' or os.environ.get('DOCKERHUB_URL') == None:
+        owner = "{}/{}".format(os.environ.get('DOCKERHUB_URL'), owner)
     # Generate local build command
     if (command == "build"):
         cmd = "docker build -q -f \"{}/{}/Dockerfile\" -t \"{}/{}:{}\" \"{}/{}/\"".format(
@@ -320,10 +323,18 @@ def pytest_cleanup(dockerfile_path):
 
 
 def docker_login():
-    login_command = "echo {} |  docker login --password-stdin -u {} {}".format(os.environ.get(
-        'DOCKERHUB_PW'), os.environ.get('DOCKERHUB_UN'), os.environ.get('DOCKERHUB_ORG')).split(" ")
-    login_command = subprocess.Popen(login_command, stdout = subprocess.DEVNULL, stderr = subprocess.DEVNULL)
-    login_code = login_command.wait()
+    if str(os.environ.get('DOCKERHUB_URL')).lower() == "none" or str(os.environ.get('DOCKERHUB_URL')).lower() == 'null' or os.environ.get('DOCKERHUB_URL') == None:
+        print("DockerHub repository found, logging in.".format(
+            os.environ.get('DOCKERHUB_URL')), file=sys.stderr)
+        login_command = "docker login -p {} -u {}".format(os.environ.get(
+            'DOCKERHUB_PW'), os.environ.get('DOCKERHUB_UN')).split(" ")
+    else:
+        print("Non-DockerHub repository found, adding URL {} and logging in.".format(os.environ.get('DOCKERHUB_URL')), file=sys.stderr)
+        login_command="docker login {} -p {} -u {}".format(os.environ.get(
+            'DOCKERHUB_URL'), os.environ.get('DOCKERHUB_PW'), os.environ.get('DOCKERHUB_UN')).split(" ")
+    login_command=subprocess.Popen(
+        login_command, stderr=open(os.devnull, "w+"))
+    login_code=login_command.wait()
     if login_code != 0:
         print("Error logging in to container reposity specified.")
         exit(1)
@@ -334,14 +345,14 @@ def main():
     Main method, takes the command to be run
     :param command: the command to be run
     """
-    arglen = len(sys.argv)
+    arglen=len(sys.argv)
     if arglen < 1:
         print("Usage python3 scripts/functions.py <command> <list of required variables for the command>")
         sys.exit(1)
     else:
-        command = sys.argv[1]
-        if command == 'fetch_develop':
-            fetch_develop()
+        command=sys.argv[1]
+        if command == 'fetch_deploy_branch':
+            fetch_deploy_branch()
         elif command == 'build_docker_cmd':
             print(build_docker_cmd(sys.argv[2], sys.argv[3],
                                    sys.argv[5], sys.argv[4]))
@@ -361,9 +372,11 @@ def main():
                 changed_paths_in_range(get_compare_range())))
         elif command == 'check_test':
             print(check_test_image(sys.argv[2]))
+        elif command == 'login':
+            docker_login()
         else:
             print("""ERROR: Command \'{}\' not recognized.  Valid commands and their associated requirements:
-                python scripts/functions.py \'fetch_develop\' - Runs a \'git fetch\' on the deploy branch ID while also tracking the current branch under development
+                python scripts/functions.py \'fetch_deploy_branch\' - Runs a \'git fetch\' on the deploy branch ID while also tracking the current branch under development
                 python scripts/functions.py \'build_docker_cmd\',\'Docker command (ie build, pull, push)\', \'Dockerhub repository\', \'Base directory for tool\', \
                     \'Version subdirectory for tool\' - Returns a valid Docker command that you have specified on the tool requested
                 python scripts/functions.py \'esure_local_image\', \'Dockerhub repository\', \'Base directory for tool\', \'Version subdirectory for tool\' \

--- a/scripts/functions.py
+++ b/scripts/functions.py
@@ -128,7 +128,7 @@ def build_docker_cmd(command, owner, tool, version):
     # Ensure the command is lower-case
     command = command.lower()
     # Check to see if URL is needed
-    if not str(os.environ.get('DOCKERHUB_URL')).lower() == "none" or str(os.environ.get('DOCKERHUB_URL')).lower() == 'null' or os.environ.get('DOCKERHUB_URL') == None:
+    if not (str(os.environ.get('DOCKERHUB_URL')).lower() == "none" or str(os.environ.get('DOCKERHUB_URL')).lower() == 'null' or os.environ.get('DOCKERHUB_URL') == None):
         owner = "{}/{}".format(os.environ.get('DOCKERHUB_URL'), owner)
     # Generate local build command
     if (command == "build"):

--- a/scripts/functions.py
+++ b/scripts/functions.py
@@ -319,18 +319,27 @@ def pytest_cleanup(dockerfile_path):
         print("ERROR: Unable to untag the Dockerfile or remove the temporary image directory for {}".format(tool))
 
 
+def docker_login():
+    login_command = "echo {} |  docker login --password-stdin -u {} {}".format(os.environ.get(
+        'DOCKERHUB_PW'), os.environ.get('DOCKERHUB_UN'), os.environ.get('DOCKERHUB_ORG')).split(" ")
+    login_command = subprocess.Popen(login_command, stdout = subprocess.DEVNULL, stderr = subprocess.DEVNULL)
+    login_code = login_command.wait()
+    if login_code != 0:
+        print("Error logging in to container reposity specified.")
+        exit(1)
+
 
 def main():
     """
     Main method, takes the command to be run
     :param command: the command to be run
     """
-    arglen=len(sys.argv)
+    arglen = len(sys.argv)
     if arglen < 1:
         print("Usage python3 scripts/functions.py <command> <list of required variables for the command>")
         sys.exit(1)
     else:
-        command=sys.argv[1]
+        command = sys.argv[1]
         if command == 'fetch_develop':
             fetch_develop()
         elif command == 'build_docker_cmd':

--- a/scripts/functions.py
+++ b/scripts/functions.py
@@ -128,7 +128,7 @@ def build_docker_cmd(command, owner, tool, version):
     # Ensure the command is lower-case
     command = command.lower()
     # Check to see if URL is needed
-    if not (str(os.environ.get('DOCKERHUB_URL')).lower() == "none" or str(os.environ.get('DOCKERHUB_URL')).lower() == 'null' or os.environ.get('DOCKERHUB_URL') == None):
+    if 'DOCKERHUB_URL' in os.environ and not (str(os.environ.get('DOCKERHUB_URL')).lower() == "none" or str(os.environ.get('DOCKERHUB_URL')).lower() == 'null' or os.environ.get('DOCKERHUB_URL') == None):
         owner = "{}/{}".format(os.environ.get('DOCKERHUB_URL'), owner)
     # Generate local build command
     if (command == "build"):

--- a/scripts/functions.py
+++ b/scripts/functions.py
@@ -128,7 +128,7 @@ def build_docker_cmd(command, owner, tool, version):
     # Ensure the command is lower-case
     command = command.lower()
     # Check to see if URL is needed
-    if 'DOCKERHUB_URL' in os.environ and not (str(os.environ.get('DOCKERHUB_URL')).lower() == "none" or str(os.environ.get('DOCKERHUB_URL')).lower() == 'null' or os.environ.get('DOCKERHUB_URL') == None):
+    if not (str(os.environ.get('DOCKERHUB_URL')).lower() == "none" or str(os.environ.get('DOCKERHUB_URL')).lower() == 'null' or os.environ.get('DOCKERHUB_URL') == None or os.environ.get('DOCKERHUB_URL') == ''):
         owner = "{}/{}".format(os.environ.get('DOCKERHUB_URL'), owner)
     # Generate local build command
     if (command == "build"):
@@ -323,7 +323,6 @@ def pytest_cleanup(dockerfile_path):
 
 
 def docker_login():
-    print("\'{}\'".format(os.environ.get('DOCKERHUB_URL')))
     if str(os.environ.get('DOCKERHUB_URL')).lower() == "none" or str(os.environ.get('DOCKERHUB_URL')).lower() == 'null' or os.environ.get('DOCKERHUB_URL') == None:
         print("DockerHub repository found, logging in.".format(
             os.environ.get('DOCKERHUB_URL')), file=sys.stderr)

--- a/scripts/functions.py
+++ b/scripts/functions.py
@@ -323,6 +323,7 @@ def pytest_cleanup(dockerfile_path):
 
 
 def docker_login():
+    print("\'{}\'".format(os.environ.get('DOCKERHUB_URL')))
     if str(os.environ.get('DOCKERHUB_URL')).lower() == "none" or str(os.environ.get('DOCKERHUB_URL')).lower() == 'null' or os.environ.get('DOCKERHUB_URL') == None:
         print("DockerHub repository found, logging in.".format(
             os.environ.get('DOCKERHUB_URL')), file=sys.stderr)


### PR DESCRIPTION
Closes  #56 

- [x] Enable pushing and pulling of non-public images:
Fixed by creating a customized `docker login` command and no longer using the GitHub Actions Docker image, as that could only pass credentials to other images using this container.

- [ ] Enable the use of non-DockerHub-based container repositories
Also fixed with the above `docker login` command.  Requires additional DOCKERHUB_URL (ie 'awscr' or 'quay.io') secret.  If this secret is not present, then it functions as before, otherwise it will insert the custom URL into the login command.

- [ ] Create Python-based repository login
This is the fix for the previous two checks, and it is fixed by bypassing the GitHub Actions Docker container, and allows for more flexible pushing and pulling, including private repositories, and those not on DockrHub.

- [ ] Fix low disk space warning when running CI-Olnly on large repositories
System now purges all Docker containers after each successful test to free up as much disk space as possible.